### PR TITLE
Fix documentation issues for CylinderTerrain in ReadMe

### DIFF
--- a/src/CylinderTerrain.lua
+++ b/src/CylinderTerrain.lua
@@ -1,6 +1,6 @@
 -- Make cylinder terrain
 
--- DrawCylinder(radius, depth, material)
+-- DrawCylinder(radius, depth, depthOffset, material, overrideExisting)
 
 
 local RESOLUTION = 4


### PR DESCRIPTION
Previous documentation stated the arguments were [radius, depth, material] while if you scroll down, they are actually [radius, depth, depthOffset, material, overrideExisting]